### PR TITLE
Correctly fetches content of Google Shared Drives

### DIFF
--- a/lib/lt/google/api/drive.rb
+++ b/lib/lt/google/api/drive.rb
@@ -87,7 +87,9 @@ module Lt
               response = service.list_files(
                 q: "'#{folder_id}' in parents  and trashed = false",
                 fields: 'files(id, mime_type), nextPageToken',
-                page_token: page_token
+                page_token: page_token,
+                include_items_from_all_drives: true,
+                supports_all_drives: true
               )
               break if response.nil?
 
@@ -109,6 +111,7 @@ module Lt
           service.list_files(
             q: "'#{folder_id}' in parents and name = '#{name}' and mimeType = '#{MIME_FOLDER}' and trashed = false",
             fields: 'files(id)',
+            include_items_from_all_drives: true,
             supports_all_drives: true
           )&.files
         end
@@ -119,6 +122,7 @@ module Lt
           service.list_files(
             q: "'#{folder_id}' in parents and mimeType = '#{MIME_FILE}' and trashed = false",
             fields: 'files(id, name)',
+            include_items_from_all_drives: true,
             supports_all_drives: true
           )&.files
         end


### PR DESCRIPTION
Add option which allows to fetch a list of files located inside a folder inside a Google Shared Drive.